### PR TITLE
Adding escape sequence to compile-file regex

### DIFF
--- a/fsproj-menu.el
+++ b/fsproj-menu.el
@@ -87,7 +87,7 @@
 (defvar Fsproj-extension "fsproj"
   "The filename extension used by Visual Studio F# project files.")
 
-(defvar Fsproj-menu-compile-file "\\.fsi$|\\.fs$"
+(defvar Fsproj-menu-compile-file "\\.fsi$\\|\\.fs$"
   "A regexp matching file names that have the Compile build action by default.")
 
 (defvar Info-current-file) ; from info.el


### PR DESCRIPTION
The regex above never matches files as the or pattern isn't escaped as per http://www.emacswiki.org/emacs/RegularExpression this result in not being able to reorder files within the project.